### PR TITLE
feat: add validation to only checkin on allowed channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ GUILD_ID=
 APP_ID=
 
 DATABASE_URL=
+
+# Allowed Channel ID for checkin
+CHECKIN_ALLOWED_CHANNEL_ID=

--- a/src/bot/commands/checkin/checkin.ts
+++ b/src/bot/commands/checkin/checkin.ts
@@ -4,7 +4,7 @@ import { increaseUserStreak } from "../../../db/queries/user"
 import { prisma } from "../../../db/client"
 import { createCheckin } from "../../../db/queries/checkin"
 import { getYesterday, isDateToday } from "../../../utils/date"
-import { FAILED_CHECKIN_ALREADY_CHECKIN_TODAY } from "../../../constants"
+import { FAILED_CHECKIN_ALREADY_CHECKIN_TODAY, generateFailedCheckinWrongChannelID } from "../../../constants"
 
 export default {
   data: new SlashCommandBuilder()
@@ -18,6 +18,12 @@ export default {
 
   async execute(interaction: ChatInputCommandInteraction) {
     const discord_id = interaction.user.id
+    
+    const allowedCheckinChannelId = process.env.CHECKIN_ALLOWED_CHANNEL_ID!
+    if (interaction.channelId !== allowedCheckinChannelId) {
+        await interaction.reply({ content: generateFailedCheckinWrongChannelID(interaction, allowedCheckinChannelId), flags: MessageFlags.Ephemeral })
+        return
+    }
 
     let user = await interaction.client.prisma.user.findUnique({
         where: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,12 @@
+import { ChatInputCommandInteraction } from "discord.js"
+
 export const FAILED_CHECKIN_ALREADY_CHECKIN_TODAY = `**Check-in failed**\n
 You already did checkin today\n
 Come back tomorrow`
+
+export function generateFailedCheckinWrongChannelID(interaction: ChatInputCommandInteraction, allowedCheckinChannelId: string): string {
+    return `**Check-in failed**\n
+You can't checkin on this channel\n
+You need to go to ${interaction.guild?.channels.cache.get(allowedCheckinChannelId)}!
+`
+}


### PR DESCRIPTION
If you checkin on not allowed channel for checkin, you will get this error message from the bot

<img width="403" height="223" alt="image" src="https://github.com/user-attachments/assets/972e40be-7228-4e1a-b30c-615ce418bd0d" />

You need to put channelID inside .env to make it works
<img width="314" height="91" alt="image" src="https://github.com/user-attachments/assets/8c8bcf6d-1281-4782-b3fc-e717b4eb5f99" />

